### PR TITLE
fix: add missing data when custom template.

### DIFF
--- a/tools/goctl/api/gogen/genconfig.go
+++ b/tools/goctl/api/gogen/genconfig.go
@@ -3,6 +3,7 @@ package gogen
 import (
 	_ "embed"
 	"fmt"
+	"github.com/zeromicro/go-zero/tools/goctl/vars"
 	"strings"
 
 	"github.com/zeromicro/go-zero/tools/goctl/api/spec"
@@ -45,6 +46,7 @@ func genConfig(dir string, cfg *config.Config, api *spec.ApiSpec, useCasbin bool
 	for _, item := range jwtTransNames {
 		jwtTransList = append(jwtTransList, fmt.Sprintf("%s %s", item, jwtTransTemplate))
 	}
+	authImportStr := fmt.Sprintf("\"%s/rest\"", vars.ProjectOpenSourceURL)
 
 	return genFile(fileGenConfig{
 		dir:             dir,
@@ -55,8 +57,10 @@ func genConfig(dir string, cfg *config.Config, api *spec.ApiSpec, useCasbin bool
 		templateFile:    configTemplateFile,
 		builtinTemplate: configTemplate,
 		data: map[string]any{
-			"jwtTrans":  strings.Join(jwtTransList, "\n"),
-			"useCasbin": useCasbin,
+			"authImport": authImportStr,
+			"auth":       strings.Join(auths, "\n"),
+			"jwtTrans":   strings.Join(jwtTransList, "\n"),
+			"useCasbin":  useCasbin,
 		},
 	})
 }


### PR DESCRIPTION
对于，`genconfig.go` 将已移除的data添加回来

```
"authImport": authImportStr,
"auth":       strings.Join(auths, "\n"),
```

问题：不清楚如果模板中未使用传递的data会不会发生什么问题？

小纠结：清楚大佬移除这两项的原因，但作为可以自定义`template`的`goctl`，希望能够支持原本的特性（自定义Auth这个配置的名称），如果对于上面的问题的解答是：“不会发生问题”的话，那么还是希望能够将这两个数据加回来，方面诸如我这种并未使用大佬自定义的go-zero核心包的情况（大佬在核心包的`rest`包中添加了Auth struct）

= =。