### PR TITLE
feat: supported prefix. (swagger-doc)

### DIFF
--- a/tools/goctl/api/gogen/genhandlers.go
+++ b/tools/goctl/api/gogen/genhandlers.go
@@ -65,6 +65,14 @@ func genHandler(dir, rootPkg string, cfg *config.Config, group spec.Group, route
 		swaggerPath = route.Path
 	}
 
+	prefix := group.GetAnnotation(spec.RoutePrefixKey)
+	prefix = strings.ReplaceAll(prefix, `"`, "")
+	prefix = strings.TrimSpace(prefix)
+	if len(prefix) > 0 {
+		prefix = path.Join("/", prefix)
+	}
+	swaggerPath = path.Join("/", prefix, swaggerPath)
+
 	handlerDoc.WriteString(fmt.Sprintf("// swagger:route %s %s %s %s \n", route.Method, swaggerPath,
 		group.GetAnnotation("group"), strings.TrimSuffix(handler, "Handler")))
 	handlerDoc.WriteString("//\n")


### PR DESCRIPTION
handler 顶部的 swagger-doc 生成支持 prefix 定义

```
@server(
 group: test
 prefix: /api/foo
)
service api {
// comment
@handler testBar
get /bar
}
```

生成

```
swagger:route get /api/foo/bar test testBar
```