### PR TITLE
feat: supported proto map field, replace index+1 with original field …

### DIFF
--- a/tools/goctl/rpc/generator/proto/merge.go
+++ b/tools/goctl/rpc/generator/proto/merge.go
@@ -153,7 +153,7 @@ func genProtoString(data parser.Proto) string {
 		} else {
 			protoString.WriteString(fmt.Sprintf("message %s {", m.Name))
 		}
-		for i, e := range m.Elements {
+		for _, e := range m.Elements {
 			e.Accept(protox.MessageVisitor{})
 			prefixStr := ""
 			if protox.ProtoField.Repeated {
@@ -163,7 +163,7 @@ func genProtoString(data parser.Proto) string {
 				prefixStr = "optional "
 			}
 
-			protoString.WriteString(fmt.Sprintf("  %s%s %s = %d;\n", prefixStr, protox.ProtoField.Type, protox.ProtoField.Name, i+1))
+			protoString.WriteString(fmt.Sprintf("  %s%s %s = %d;\n", prefixStr, protox.ProtoField.Type, protox.ProtoField.Name, protox.ProtoField.Sequence))
 		}
 		protoString.WriteString("}\n\n")
 	}

--- a/tools/goctl/util/protox/proto.go
+++ b/tools/goctl/util/protox/proto.go
@@ -51,6 +51,7 @@ type ProtoFieldData struct {
 	Type     string
 	Repeated bool
 	Optional bool
+	Sequence int
 }
 
 type MessageVisitor struct {
@@ -62,6 +63,15 @@ func (m MessageVisitor) VisitNormalField(i *proto.NormalField) {
 	ProtoField.Type = i.Field.Type
 	ProtoField.Repeated = i.Repeated
 	ProtoField.Optional = i.Optional
+	ProtoField.Sequence = i.Sequence
+}
+
+func (m MessageVisitor) VisitMapField(i *proto.MapField) {
+	ProtoField.Name = i.Field.Name
+	ProtoField.Type = fmt.Sprintf("map<%s,%s>", i.KeyType, i.Field.Type)
+	ProtoField.Sequence = i.Sequence
+	ProtoField.Repeated = false
+	ProtoField.Optional = false
 }
 
 func GenCommentString(comments []string, space bool) string {


### PR DESCRIPTION
proto文件支持 map 类型的field

使用 原始的 `field` 顺序替换 `(index+1)`