### PR TITLE
feat: supported enum.

### DIFF
--- a/tools/goctl/rpc/parser/enum.go
+++ b/tools/goctl/rpc/parser/enum.go
@@ -1,0 +1,8 @@
+package parser
+
+import "github.com/emicklei/proto"
+
+// Enum embeds proto.Enum
+type Enum struct {
+	*proto.Enum
+}

--- a/tools/goctl/rpc/parser/parser.go
+++ b/tools/goctl/rpc/parser/parser.go
@@ -49,6 +49,9 @@ func (p *DefaultProtoParser) Parse(src string, multiple ...bool) (Proto, error) 
 		proto.WithImport(func(i *proto.Import) {
 			ret.Import = append(ret.Import, Import{Import: i})
 		}),
+		proto.WithEnum(func(enum *proto.Enum) {
+			ret.Enum = append(ret.Enum, Enum{Enum: enum})
+		}),
 		proto.WithMessage(func(message *proto.Message) {
 			ret.Message = append(ret.Message, Message{Message: message})
 		}),

--- a/tools/goctl/rpc/parser/proto.go
+++ b/tools/goctl/rpc/parser/proto.go
@@ -8,6 +8,7 @@ type Proto struct {
 	PbPackage string
 	GoPackage string
 	Import    []Import
+	Enum      []Enum
 	Message   []Message
 	Service   Services
 }

--- a/tools/goctl/util/protox/proto.go
+++ b/tools/goctl/util/protox/proto.go
@@ -74,6 +74,14 @@ func (m MessageVisitor) VisitMapField(i *proto.MapField) {
 	ProtoField.Optional = false
 }
 
+func (m MessageVisitor) VisitEnumField(i *proto.EnumField) {
+	ProtoField.Name = i.Name
+	ProtoField.Type = ""
+	ProtoField.Sequence = i.Integer
+	ProtoField.Repeated = false
+	ProtoField.Optional = false
+}
+
 func GenCommentString(comments []string, space bool) string {
 	var commentsString strings.Builder
 	var spaceString string


### PR DESCRIPTION
原先不支持对enum的merge

添加 merge 对enum的支持

```proto3
// 操作类型
enum Operator {
  EQ = 0; // ==
  NEQ = 1; // !=
  IN = 2; // in ()
  NotIn = 3; // not in ()
  GT = 4; // >
  GTE = 5; // >=
  LT = 6; // <
  LTE = 7; // <=
  Contains = 8; // %{}%
  Prefix = 9; // {}%
  Suffix = 10; // %{}
  EqualFold = 11; // == with toLower
  ContainsFold = 12; // %{}% with toLower
}
```